### PR TITLE
docs: Highlight remote install command at top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,24 @@
 
 A prompt engineering template that enables Claude Code to assist with software development through specialized personas, providing structured workflows and organized task management.
 
+## 🚀 Quick Start
+
+**Get started in 30 seconds with one command:**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/kholcomb/ClaudeCode_Prompting_Framework/refs/heads/main/setup-framework.sh | bash -s -- --remote
+```
+
+*No cloning required! This command downloads and sets up the complete framework in your current directory.*
+
+**Alternative with wget:**
+```bash
+wget -qO- https://raw.githubusercontent.com/kholcomb/ClaudeCode_Prompting_Framework/refs/heads/main/setup-framework.sh | bash -s -- --remote
+```
+
 ## Table of Contents
 
+- [Quick Start](#-quick-start)
 - [Overview](#overview)
 - [Key Features](#key-features)
 - [Framework Structure](#framework-structure)
@@ -14,7 +30,7 @@ A prompt engineering template that enables Claude Code to assist with software d
 - [Framework Components](#framework-components)
 - [Usage Examples](#usage-examples)
 - [Best Practices](#best-practices)
-- [New Commands](#new-commands)
+- [Available Commands](#available-commands)
 - [Troubleshooting](#troubleshooting)
 
 ## Overview


### PR DESCRIPTION
## Summary
- Add prominent Quick Start section with one-command setup at the top of README
- Emphasize the 30-second remote installation process
- Include both curl and wget alternatives for cross-platform compatibility
- Update Table of Contents to include the new Quick Start section

## Changes
- **🚀 Quick Start section** prominently placed after title
- **⚡ One-command remote install** highlighted with copy-paste ready code blocks
- **📋 Updated Table of Contents** to include Quick Start reference
- **🔄 Cross-platform support** with both curl and wget examples

## Benefits
- **Immediate visibility** of the easiest installation method
- **Reduced friction** for new users wanting to try the framework
- **Clear call-to-action** that gets users started in 30 seconds
- **Better user experience** with no need to read through documentation first

🤖 Generated with [Claude Code](https://claude.ai/code)