### PR TITLE
fix: Critical setup script fixes for remote installation

### DIFF
--- a/setup-framework.sh
+++ b/setup-framework.sh
@@ -119,6 +119,13 @@ PURPLE='\033[0;35m'
 CYAN='\033[0;36m'
 NC='\033[0m' # No Color
 
+# Print colored output
+print_info() { echo -e "${BLUE}ℹ️  $1${NC}"; }
+print_success() { echo -e "${GREEN}✅ $1${NC}"; }
+print_warning() { echo -e "${YELLOW}⚠️  $1${NC}"; }
+print_error() { echo -e "${RED}❌ $1${NC}"; }
+print_header() { echo -e "${PURPLE}$1${NC}"; }
+
 # Framework version
 if [[ -f VERSION ]]; then
     FRAMEWORK_VERSION=$(cat VERSION)
@@ -126,13 +133,6 @@ else
     print_warning "VERSION file not found, using default version 1.3.0"
     FRAMEWORK_VERSION="1.3.0"
 fi
-
-# Print colored output
-print_info() { echo -e "${BLUE}ℹ️  $1${NC}"; }
-print_success() { echo -e "${GREEN}✅ $1${NC}"; }
-print_warning() { echo -e "${YELLOW}⚠️  $1${NC}"; }
-print_error() { echo -e "${RED}❌ $1${NC}"; }
-print_header() { echo -e "${PURPLE}$1${NC}"; }
 
 # ASCII Art Banner
 show_banner() {
@@ -753,7 +753,7 @@ main() {
     fi
     
     # Show completion
-    show_completion
+    show_completion "$remote_mode"
 }
 
 # Usage information


### PR DESCRIPTION
## Summary
Fixes critical errors in the setup script that prevented remote installation from working.

## Issues Fixed
1. **Function ordering error**: `print_warning` was called before being defined
   - Error: `bash: line 126: print_warning: command not found`
   - Fix: Moved print function definitions before VERSION file check

2. **Missing parameter error**: `show_completion` function expected `$1` parameter
   - Fix: Pass `$remote_mode` parameter to `show_completion` function

## Testing
- ✅ Script syntax validation passes (`bash -n`)
- ✅ Remote setup command now works without errors
- ✅ All function calls properly parameterized

## Impact
- **Critical fix** for the remote installation feature highlighted in README
- Ensures the one-command setup works as advertised
- Improves user experience for new framework users

🤖 Generated with [Claude Code](https://claude.ai/code)